### PR TITLE
fix dae repr error

### DIFF
--- a/kaggler/__init__.py
+++ b/kaggler/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.10'
+__version__ = '0.9.11'
 __all__ = ['const',
            'data_io',
            'ensemble',

--- a/kaggler/__init__.py
+++ b/kaggler/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.8'
+__version__ = '0.9.9'
 __all__ = ['const',
            'data_io',
            'ensemble',

--- a/kaggler/preprocessing/autoencoder.py
+++ b/kaggler/preprocessing/autoencoder.py
@@ -285,6 +285,7 @@ class DAE(base.BaseEstimator):
         Returns:
             Encoding matrix for features
         """
+        X = X.copy()
         if self.cat_cols:
             X[self.cat_cols] = self.lbe.transform(X[self.cat_cols])
 


### PR DESCRIPTION
This PR fixes an error raised when printing the `DAE`/`SDAE` object because `__repr__()` is not defined. Instead of manually defining `__repr__()`, it is fixed by following scikit-learn's guidelines for custom estimators.

* update random_state/seed arguments in DAE/DAELayer to follow sklearn/tf conventions
* up the version to v0.9.11