### PR TITLE
Handle edge case in one hot encoding transformation

### DIFF
--- a/kaggler/preprocessing/categorical.py
+++ b/kaggler/preprocessing/categorical.py
@@ -226,10 +226,11 @@ class OneHotEncoder(base.BaseEstimator):
             self.is_fitted
         ), "fit() or fit_transform() must be called before transform()."
 
+        X_new = None
         for i, col in enumerate(X.columns):
             X_col = self._transform_col(X[col], i)
             if X_col is not None:
-                if i == 0:
+                if X_new is None:
                     X_new = X_col
                 else:
                     X_new = sparse.hstack((X_new, X_col))
@@ -238,6 +239,9 @@ class OneHotEncoder(base.BaseEstimator):
                 "{} --> {} features".format(col, self.label_encoder.label_maxes[i])
             )
 
+        assert (
+                X_new is not None
+        ), "no column was transformed, please check your dataframe input"
         return X_new
 
     def fit_transform(self, X, y=None):


### PR DESCRIPTION
Assign `X_new` to the **first non-null** transformed column `X_col` rather than **only the first column**. There was a potential [issue](https://github.com/uber/causalml/issues/764) discussed in [CausalML](https://github.com/uber/causalml/) community, it used Kaggler's feature transformation library and we can merge back the PR contribution made there.

